### PR TITLE
Add start_package_http target to run simple HTTP server  in fs/output/xpackage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -463,7 +463,9 @@ install_bootloader:: install_intro getuboot getdvsdk
 	$(ECHO) "\033[32m   done\033[0m"
 	$(ECHO) ""
 
-install_kernel_fs:
+install_kernel_fs: install_kernel install_fs
+
+install_kernel:
 	$(V)if [ ! -f kernel/arch/arm/boot/uImage ] ; then $(M_ECHO) ""; $(M_ECHO) "\033[31mFile uImage not found, aborting\033[0m"; exit 1; fi
 	$(V)if [ ! -f addons/uEnv.txt ] ; then $(M_ECHO) ""; $(M_ECHO) "\033[31mFile uEnv.txt not found, aborting\033[0m"; exit 1; fi
 	$(ECHO) ""
@@ -473,6 +475,7 @@ install_kernel_fs:
 	$(ECHO) "\033[32m   done\033[0m"
 	$(ECHO) ""
 
+install_fs:
 	$(V)if [ ! -f fs/output/images/rootfs.tar ]; then $(M_ECHO) ""; $(M_ECHO) "\033[31mFile rootfs.tar not found, aborting\033[0m"; exit 1; fi
 	$(ECHO) "\033[1mCopying root filesystem\033[0m"
 	$(V)sudo tar xvf fs/output/images/rootfs.tar -C $(MOUNTPOINT)/rootfs $(OUTPUT)


### PR DESCRIPTION
Run simple HTTP server  in fs/output/xpackage to install
freshly build packages directly from SDK/fs without any copying or SD
card swap.

The HTTP server is a sample python package bundled with most of python
releases.

To install fresh build packages from your SDK root.

On SDK host:
1. build your favorite package
2. Run server 'make  start_package_http' in SDK root dir

On virt2real:
1. Update virt2real's /etc/opkg/opkg.conf with the following line
   src "all" http://<your-machine-IP-address>:8000
   This need to be done just once.
2. Update package list with 'opkg-cl update'
3. Install package with 'opkg-cl install <your-favorite-package-name>'
